### PR TITLE
Fixed languages regex

### DIFF
--- a/lib/code-lexer/languages/java.yml
+++ b/lib/code-lexer/languages/java.yml
@@ -1,6 +1,6 @@
 lexer:
     keyword:
-        - (?:^abstract$|^assert$|^arguments$|^boolean$|^break$|^byte$|^case$|^catch$|^char$|^const$|^continue$|^debugger$|^default$|^delete$|^double$|^do$|^else$|^eval$|^false$|^finally$|^final$|^float$|^for$|^function$|^goto$|^if$|^implements$|^int$|^in$|^instanceof$|^interface$|^let$|^long$|^native$|^new$|^null$|^package$|^private$|^protected$|^public$|^return$|^short$|^static$|^switch$|^synchronized$|^this$|^throws$|^throw$|^transient$|^true$|^try$|^typeof$|^var$|^void$|^volatile$|^while$|^with$|^yield$|^class$|^enum$|^export$|^extends$|^import$|^super$|^from$|^strictfp$)
+        - (?:abstract|arguments|boolean|break|byte|case|catch|char|const|continue|debugger|default|delete|double|do|else|eval|false|finally|final|float|for|function|goto|if|implements|int|in|instanceof|interface|let|long|native|new|null|package|private|protected|public|return|short|static|switch|synchronized|this|throws|throw|transient|true|try|typeof|var|void|volatile|while|with|yield|class|enum|export|extends|import|super|from|strictfp)
     identifier:
         - "[$A-Za-z_][$A-Za-z0-9_]*"
     comment:

--- a/lib/code-lexer/languages/javascript.yml
+++ b/lib/code-lexer/languages/javascript.yml
@@ -1,6 +1,6 @@
 lexer:
     keyword:
-        - (?:^abstract$|^arguments$|^boolean$|^break$|^byte$|^case$|^catch$|^char$|^const$|^continue$|^debugger$|^default$|^delete$|^double$|^do$|^else$|^eval$|^false$|^finally$|^final$|^float$|^for$|^function$|^goto$|^if$|^implements$|^int$|^in$|^instanceof$|^interface$|^let$|^long$|^native$|^new$|^null$|^package$|^private$|^protected$|^public$|^return$|^short$|^static$|^switch$|^synchronized$|^this$|^throws$|^throw$|^transient$|^true$|^try$|^typeof$|^var$|^void$|^volatile$|^while$|^with$|^yield$|^class$|^enum$|^export$|^extends$|^import$|^super$|^from$)
+        - (?:abstract|arguments|boolean|break|byte|case|catch|char|const|continue|debugger|default|delete|double|do|else|eval|false|finally|final|float|for|function|goto|if|implements|int|in|instanceof|interface|let|long|native|new|null|package|private|protected|public|return|short|static|switch|synchronized|this|throws|throw|transient|true|try|typeof|var|void|volatile|while|with|yield|class|enum|export|extends|import|super|from)
     identifier:
         - "[$A-Za-z_][$A-Za-z0-9_]*"
     comment:


### PR DESCRIPTION
- Removed ^ and $ from keywords
- Ordered keywords in regex in order to avoid to abstract "int" in "in ID1"